### PR TITLE
Changes to metadata

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -4,10 +4,10 @@ import { ArrowLeft, Users, Target, Heart, Zap } from 'lucide-react';
 import Footer from '@/app/components/Footer';
 
 export const metadata: Metadata = {
-  title: 'About Us - Journly',
+  title: 'About Us',
   description: 'Learn about Journly, our mission to democratize content creation, and the team behind the platform.',
   openGraph: {
-    title: 'About Us - Journly',
+    title: 'About Us',
     description: 'Learn about Journly, our mission to democratize content creation, and the team behind the platform.',
     type: 'website',
   },

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -4,10 +4,10 @@ import { ArrowLeft, Mail, MessageCircle, HelpCircle, Bug, Lightbulb } from 'luci
 import Footer from '@/app/components/Footer';
 
 export const metadata: Metadata = {
-  title: 'Contact Us - Journly',
+  title: 'Contact Us',
   description: 'Get in touch with the Journly team. We\'re here to help with questions, feedback, and support.',
   openGraph: {
-    title: 'Contact Us - Journly',
+    title: 'Contact Us',
     description: 'Get in touch with the Journly team. We\'re here to help with questions, feedback, and support.',
     type: 'website',
   },

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -129,7 +129,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     console.error('Error generating metadata for post:', error);
 
     return {
-      title: "Post Not Found - Journly",
+      title: "Post Not Found",
       description: "The requested post could not be found.",
     };
   }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -4,10 +4,10 @@ import { ArrowLeft, Shield, Eye, Lock, Database } from 'lucide-react';
 import Footer from '@/app/components/Footer';
 
 export const metadata: Metadata = {
-  title: 'Privacy Policy - Journly',
+  title: 'Privacy Policy',
   description: 'Learn how Journly collects, uses, and protects your personal information. Your privacy is our priority.',
   openGraph: {
-    title: 'Privacy Policy - Journly',
+    title: 'Privacy Policy',
     description: 'Learn how Journly collects, uses, and protects your personal information. Your privacy is our priority.',
     type: 'website',
   },

--- a/src/app/subscription/page.tsx
+++ b/src/app/subscription/page.tsx
@@ -11,7 +11,7 @@ import { hasActiveSubscription } from "@/lib/services/subscription-service";
 import { SubscriptionButton } from "@/app/components/subscription/SubscriptionButton";
 
 export const metadata: Metadata = {
-  title: "Subscription Plans - Journly",
+  title: "Subscription Plans",
   description: "Choose a subscription plan to access unlimited articles on Journly.",
 };
 

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -4,10 +4,10 @@ import { ArrowLeft, FileText, Users, Shield, AlertTriangle, CheckCircle, XCircle
 import Footer from '@/app/components/Footer';
 
 export const metadata: Metadata = {
-  title: 'Terms of Service - Journly',
+  title: 'Terms of Service',
   description: 'Read our terms of service to understand the rules and guidelines for using Journly.',
   openGraph: {
-    title: 'Terms of Service - Journly',
+    title: 'Terms of Service',
     description: 'Read our terms of service to understand the rules and guidelines for using Journly.',
     type: 'website',
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Simplified page titles and Open Graph titles across multiple pages by removing the " - Journly" suffix. Titles now display as "About Us", "Contact Us", "Post Not Found", "Privacy Policy", "Subscription Plans", and "Terms of Service" for a cleaner appearance in browsers and social sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->